### PR TITLE
Fixes parsing of (See: ) references

### DIFF
--- a/__tests__/Container.test.js
+++ b/__tests__/Container.test.js
@@ -124,7 +124,7 @@ describe.only('Container Tests', () => {
     expect(note).toEqual(expectedNote);
   });
 
-  it('Test CheckInfoCardWrapper.getNote() where Bible verse at the end does NOT get removed', () => {
+  it('Test CheckInfoCardWrapper.getNote() where Bible verse at the end does NOT get removed, nothing should change', () => {
     const props = {
       showHelps: true,
       toggleHelps: jest.fn(),
@@ -139,7 +139,6 @@ describe.only('Container Tests', () => {
     }
     const checkInfoCardWrapper = shallow(<CheckInfoCardWrapper {...props} />);
     const note = checkInfoCardWrapper.instance().getNote(props.contextId.occurrenceNote);
-    const expectedNote = 'Paul speaks of God’s message as if it were an object (not abstract) ([Titus 2:11](rc://en/ult/book/tit/02/11))';
-    expect(note).toEqual(expectedNote);
+    expect(note).toEqual(props.contextId.occurrenceNote);
   });
 });

--- a/__tests__/Container.test.js
+++ b/__tests__/Container.test.js
@@ -131,7 +131,7 @@ describe.only('Container Tests', () => {
       groupsIndex: [{id: 'figs-metaphor', name: 'Metaphor'}],
       contextId: {
         groupId: 'figs-metaphor',
-        occurrenceNote: 'Paul speaks of God’s message as if it were an object (not abstract) ([Titus 2:11](rc://en/ult/book/tit/02/11))',
+        occurrenceNote: 'Paul said this in another verse ([Titus 1:5](rc://en/ult/book/tit/01/05))',
         tool: 'translationNotes',
       },
       resourcesReducer: {},

--- a/__tests__/Container.test.js
+++ b/__tests__/Container.test.js
@@ -112,7 +112,7 @@ describe.only('Container Tests', () => {
       groupsIndex: [{id: 'figs-metaphor', name: 'Metaphor'}],
       contextId: {
         groupId: 'figs-metaphor',
-        occurrenceNote: 'Paul speaks of God’s message as if it were an object (not abstract) that could be visibly shown to people. Alternate translation: “He caused me to understand his message” (See: [Idiom](rc://en/ta/man/translate/figs-idiom), [[rc://some/unknown/link]] and [Metaphor](rc://en/ta/man/translate/figs-metaphor))',
+        occurrenceNote: 'Paul speaks of God’s message as if it were an object (not abstract) ([Titus 2:11](rc://en/ult/book/tit/02/11)) that could be visibly shown to people. Alternate translation: “He caused me to understand his message” (See: [Idiom](rc://en/ta/man/translate/figs-idiom), [[rc://some/unknown/link]] and [Metaphor](rc://en/ta/man/translate/figs-metaphor)) ',
         tool: 'translationNotes',
       },
       resourcesReducer: {},
@@ -120,7 +120,26 @@ describe.only('Container Tests', () => {
     }
     const checkInfoCardWrapper = shallow(<CheckInfoCardWrapper {...props} />);
     const note = checkInfoCardWrapper.instance().getNote(props.contextId.occurrenceNote);
-    const expectedNote = "Paul speaks of God’s message as if it were an object (not abstract) that could be visibly shown to people. Alternate translation: “He caused me to understand his message”";
+    const expectedNote = 'Paul speaks of God’s message as if it were an object (not abstract) ([Titus 2:11](rc://en/ult/book/tit/02/11)) that could be visibly shown to people. Alternate translation: “He caused me to understand his message”';
+    expect(note).toEqual(expectedNote);
+  });
+
+  it('Test CheckInfoCardWrapper.getNote() where Bible verse at the end does NOT get removed', () => {
+    const props = {
+      showHelps: true,
+      toggleHelps: jest.fn(),
+      groupsIndex: [{id: 'figs-metaphor', name: 'Metaphor'}],
+      contextId: {
+        groupId: 'figs-metaphor',
+        occurrenceNote: 'Paul speaks of God’s message as if it were an object (not abstract) ([Titus 2:11](rc://en/ult/book/tit/02/11))',
+        tool: 'translationNotes',
+      },
+      resourcesReducer: {},
+      translate: k => k,
+    }
+    const checkInfoCardWrapper = shallow(<CheckInfoCardWrapper {...props} />);
+    const note = checkInfoCardWrapper.instance().getNote(props.contextId.occurrenceNote);
+    const expectedNote = 'Paul speaks of God’s message as if it were an object (not abstract) ([Titus 2:11](rc://en/ult/book/tit/02/11))';
     expect(note).toEqual(expectedNote);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "checking-tool-wrapper",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "checking-tool-wrapper",
   "description": "Checking tool wrapper for translationCore App",
-  "version": "0.4.31",
+  "version": "0.4.32",
   "main": "dist/bundle.js",
   "scripts": {
     "test": "eslint ./src && jest",

--- a/src/components/CheckInfoCardWrapper.js
+++ b/src/components/CheckInfoCardWrapper.js
@@ -40,10 +40,10 @@ class CheckInfoCardWrapper extends React.Component {
   }
 
   getNote(occurrenceNote) {
-    // Removes any rc:// links and the text around it, where everything is between ( and )
+    // Removes the (See: [...](rc://...)) links at the end of an occurrenceNote
     // Ex: Paul speaks of God’s message as if it were an object (See: [Idiom](rc://en/ta/man/translate/figs-idiom) and [Metaphor](rc://en/ta/man/translate/figs-metaphor)) =>
     //     Paul speaks of God’s message as if it were an object
-    return occurrenceNote.replace(/\s*\([^\)]*((\[[^\[\]]+\])*(\[\[|\()+rc:\/\/[^\)\]]+(\]\]|\))[^\(\[\)\]]*)+[^\)]*\)/g, "");
+    return occurrenceNote.replace(/\s*\([^\(\)\[\]]+((\[[^\[\]]+\])*(\[\[|\()+rc:\/\/[^\)\]]+(\]\]|\))[^\(\[\)\]]*)+[^\(\)\[\]]*\)\s*$/g, "");
   }
 
   getScriptureFromReference(lang, id, book, chapter, verse) {


### PR DESCRIPTION
Now only removes the "see also" references if they are at the end of a occurrenceNote and at least 1 character appears before the markdown link (the "See:" part in the language). Thus if a Bible verse is even at the end of the note, such as

```Paul said this in another verse ([Titus 1:5](rc://en/ult/book/tit/01/05))```

It will still leave that verse reference.